### PR TITLE
Add Pulser measurements

### DIFF
--- a/ppc01/doc/bch/readme_bch_overview.md
+++ b/ppc01/doc/bch/readme_bch_overview.md
@@ -1,0 +1,21 @@
+## <img src="./../../logo/lbnl_logo.png" alt="logo" width="150"/> Teststand overview  - `bch` (benchtest)
+This is an overview of the LBNL teststand `ppc01` measurements. For more details on the individuals runs, see the readme files in this directory. 
+The follow the following naming scheme: `readme_<category>_<period>_<runs>.md`.  
+
+<style>
+@media (prefers-color-scheme: dark) {
+  .logo-inline {
+    content: url("./../../logo/lbnl_logo_dark.png");
+  }
+}
+</style>
+
+## Overview table: period 1 `p01`   
+All runs in this period are taken this the **ASIC L1k65n**. The Germanium detector is not connected. 
+|          |                 |                 |            |                       |
+| :------- | :-------------- | :-------------- | :--------- | :-------------------- |
+| **runs** | **# waveforms** | **temperature** | **cables** | **short description** |
+| `r001`   |                 | 295 K (room)    | 185 cm     | pulser  ` C = 500 fF` |
+|          |                 |                 |            |                       |
+
+

--- a/ppc01/doc/bch/readme_bch_overview.md
+++ b/ppc01/doc/bch/readme_bch_overview.md
@@ -11,11 +11,14 @@ The follow the following naming scheme: `readme_<category>_<period>_<runs>.md`.
 </style>
 
 ## Overview table: period 1 `p01`   
-All runs in this period are taken this the **ASIC L1k65n**. The Germanium detector is not connected. 
-|          |                 |                 |            |                       |
-| :------- | :-------------- | :-------------- | :--------- | :-------------------- |
-| **runs** | **# waveforms** | **temperature** | **cables** | **short description** |
-| `r001`   |                 | 295 K (room)    | 185 cm     | pulser  ` C = 500 fF` |
-|          |                 |                 |            |                       |
+All runs in this period are taken this the **ASIC L1k65n + buffer**. The Germanium detector is not connected. For more detail, see `readme_bch_p01.md`
+|               |                 |                 |            |                       |
+| :------------ | :-------------- | :-------------- | :--------- | :-------------------- |
+| **runs**      | **# waveforms** | **temperature** | **cables** | **short description** |
+| `r001 - r010` |                 | 295 K (room)    | 185 cm     | linearity data        |
+| `r011`        |                 | 295 K (room)    | 185 cm     | noise run             |
+| `r012`        |                 | 90 K            | 185 cm     | noise run             |
+| `r013 - r022` |                 | 90 K            | 185 cm     | linearity data        |
+|               |                 |                 |            |                       |
 
 

--- a/ppc01/doc/bch/readme_bch_p01.md
+++ b/ppc01/doc/bch/readme_bch_p01.md
@@ -1,0 +1,93 @@
+## <img src="./../../logo/lbnl_logo.png" alt="logo" width="150"/> Teststand data 
+LBNL measurement protocol for benchtest "`bch`"
+
+<style>
+@media (prefers-color-scheme: dark) {
+  .logo-inline {
+    content: url("./../../logo/lbnl_logo_dark.png");
+  }
+}
+</style>
+
+## General measurement information
+|                                  |                                                    |
+| :------------------------------- | :------------------------------------------------- |
+| Setup name                       | `ppc01`                                            |
+| period                           | 1                                                  |
+| Location                         | LBNL, building 70,  room 70-141                    |
+| Date of measurement (yyyy-mm-dd) | 2025-03-17                                         |
+| Operators                        | Marcos Turqueti, Lisa Schlueter, Ryutaro Matsumoto |
+| Goal of measurement              | Benchtest ASIC: Linearity and noise performance    |
+|                                  |                                                    |
+
+## Experimental setup description
+- ASIC in vacuum chamber, but kept at atmospheric pressure (no vacuum). In this setup, the chamber is used for em-shielding. 
+- Germanium detector is not connected to ASIC. 
+- Pulser is direclty connected to the CSA. 
+- For `90 K` measurements, the chamber is cooled via cold finger in liquid nitrogen dewar.
+
+## Electronics
+LBNL ASIC `l1k65n`. Board `A`. The **buffer** is activated and we make use of the differential output. The positive and negative output waveforms are subtracted frmo each other. We use a board with charged capacitors + LDO for the ASIC power supply. 
+
+|        |  **runs**       | **Description** |
+| :----- | :-----          | :---------------|
+| CSA    | all             |`l1k65n`         |
+| Buffer | all             | yes, but use only single output             |
+| `V_ref`| all            | `+ 2.6 V` (super cap board)      |    
+
+## Pulser
+- capacitance `C = 500 fF` (outside of chamber. shielded with copper tape)
+- pulse generator: TELEDYNE `T3AFG500`
+  - frequency = `20 Hz` 
+  - pulse width = `30 ms`
+  - fall edge = `20 ms`
+  - amplitude (peak-to-peak): varied
+
+## DAQ
+Skutek Digitizer "FemtoDAQ Vireo". 
+Used one of the optimal configuration of parameters.
+|                            |                                     |
+| :------------------------- | :---------------------------------- |
+|                            |                                     |
+| Sample rate                | `100 MHz`                           |
+| Number of samples          | `4096`                              |
+| Waveform length            | `40.96 µs`                          |
+| Resolution                 | `14` bit                            |
+| Coupling mode              | `DC coupled`                        |
+| channel 0                  | CSA output positive                 |
+| channel 1                  | pulser                              |
+| Analog Offsets (ch0, ch1)  | `-100`, `0`                         |
+| Digital Offsets (ch0, ch1) | `0`, `0`                            |
+| Termination                | `1 kΩ`                              |
+| Trigger on                 | pulser                              |
+| Trigger Averaging Window   | `0.32` µs                           |
+| Trigger position approx.   | `8 µs`, exception: `r011 -> 40.9 µs` |
+| Trigger threshold          | 500 `r001`-`r004`                   |
+|                            | 300 `r005`                          |
+|                            | 100 `r006-r010`                     |
+|                            | 1 on ch0. `r11`                          |
+
+
+## Remarks and comments
+
+|          |                 |                         |             |
+| :------- | :-------------- | :---------------------- | :---------- |
+| **runs** | **# waveforms** | **pulser voltage (pp)** | **comment** |
+| `r001`   | 5,000           | `300 mV`                |             |
+| `r002`   | 5,000           | `400 mV`                |             |
+| `r003`   | 5,000           | `500 mV`                |             |
+| `r004`   | 5,000           | `100 mV`                |             |
+| `r005`   | 5,000           | `50 mV`                 |             |
+| `r006`   | 5,000           | `25 mV`                 |             |
+| `r007`   | 5,000           | `150 mV`                |             |
+| `r008`   | 5,000           | `200 mV`                |             |
+| `r009`   | 5,000           | `250 mV`                |             |
+| `r010`   | 5,000           | `350 mV`                |             |
+| `r011`   | 50,000          | not connected to ASIC   | noise run   |
+|          |                 |                         |             |
+
+
+
+
+
+

--- a/ppc01/doc/bch/readme_bch_p01.md
+++ b/ppc01/doc/bch/readme_bch_p01.md
@@ -10,83 +10,98 @@ LBNL measurement protocol for benchtest "`bch`"
 </style>
 
 ## General measurement information
-|                                  |                                                    |
-| :------------------------------- | :------------------------------------------------- |
-| Setup name                       | `ppc01`                                            |
-| period                           | 1                                                  |
-| Location                         | LBNL, building 70,  room 70-141                    |
-| Date of measurement (yyyy-mm-dd) | 2025-03-17                                         |
-| Operators                        | Marcos Turqueti, Lisa Schlueter, Ryutaro Matsumoto |
-| Goal of measurement              | Benchtest ASIC: Linearity and noise performance    |
-|                                  |                                                    |
+|                                  |                                                              |
+| :------------------------------- | :----------------------------------------------------------- |
+| Setup name                       | `ppc01`                                                      |
+| period                           | 1                                                            |
+| Location                         | LBNL, building 70,  room 70-141                              |
+| Date of measurement (yyyy-mm-dd) | 2025-03-17 (`r001 - r011`),     2025-03-18   (`r012 - r022`) |
+| Operators                        | Lisa Schlueter, Marcos Turqueti,                               |
+| Goal of measurement              | Benchtest ASIC: Linearity and noise performance              |
+|                                  |                                                              |
 
 ## Experimental setup description
 - ASIC in vacuum chamber, but kept at atmospheric pressure (no vacuum). In this setup, the chamber is used for em-shielding. 
 - Germanium detector is not connected to ASIC. 
 - Pulser is direclty connected to the CSA. 
+- For room termperature measurements, the chamber is in a "warm" dewar (not cooled).
 - For `90 K` measurements, the chamber is cooled via cold finger in liquid nitrogen dewar.
 
 ## Electronics
-LBNL ASIC `l1k65n`. Board `A`. The **buffer** is activated and we make use of the differential output. The positive and negative output waveforms are subtracted frmo each other. We use a board with charged capacitors + LDO for the ASIC power supply. 
+LBNL ASIC `l1k65n` + buffer. Board `A`. We use a board with charged capacitors + LDO for the ASIC power supply. 
 
-|        |  **runs**       | **Description** |
-| :----- | :-----          | :---------------|
-| CSA    | all             |`l1k65n`         |
-| Buffer | all             | yes, but use only single output             |
-| `V_ref`| all            | `+ 2.6 V` (super cap board)      |    
+|         | **runs** | **Description**                 |
+| :------ | :------- | :------------------------------ |
+| CSA     | all      | `l1k65n`                        |
+| Buffer  | all      | yes, but use only single output |
+| `V_ref` | all      | `+ 2.6 V` (super cap board)     |
 
 ## Pulser
-- capacitance `C = 500 fF` (outside of chamber. shielded with copper tape)
+- capacitance `C = 500 fF` (outside of chamber. shielded with copper foil)
 - pulse generator: TELEDYNE `T3AFG500`
   - frequency = `20 Hz` 
   - pulse width = `30 ms`
   - fall edge = `20 ms`
-  - amplitude (peak-to-peak): varied
+  - amplitude (peak-to-peak): varied `25 mV` - `500 mV`
 
 ## DAQ
 Skutek Digitizer "FemtoDAQ Vireo". 
 Used one of the optimal configuration of parameters.
-|                            |                                     |
-| :------------------------- | :---------------------------------- |
-|                            |                                     |
-| Sample rate                | `100 MHz`                           |
-| Number of samples          | `4096`                              |
-| Waveform length            | `40.96 µs`                          |
-| Resolution                 | `14` bit                            |
-| Coupling mode              | `DC coupled`                        |
-| channel 0                  | CSA output positive                 |
-| channel 1                  | pulser                              |
-| Analog Offsets (ch0, ch1)  | `-100`, `0`                         |
-| Digital Offsets (ch0, ch1) | `0`, `0`                            |
-| Termination                | `1 kΩ`                              |
-| Trigger on                 | pulser                              |
-| Trigger Averaging Window   | `0.32` µs                           |
+|                            |                                      |
+| :------------------------- | :----------------------------------- |
+|                            |                                      |
+| Sample rate                | `100 MHz`                            |
+| Number of samples          | `4096`                               |
+| Waveform length            | `40.96 µs`                           |
+| Resolution                 | `14` bit                             |
+| Coupling mode              | `DC coupled`                         |
+| channel 0                  | CSA output positive                  |
+| channel 1                  | pulser                               |
+| Analog Offsets (ch0, ch1)  | `-100`, `0`                          |
+| Digital Offsets (ch0, ch1) | `0`, `0`                             |
+| Termination                | `1 kΩ`                               |
+| Trigger on                 | pulser                               |
+| Trigger Averaging Window   | `0.32` µs                            |
 | Trigger position approx.   | `8 µs`, exception: `r011 -> 40.9 µs` |
-| Trigger threshold          | 500 `r001`-`r004`                   |
-|                            | 300 `r005`                          |
-|                            | 100 `r006-r010`                     |
-|                            | 1 on ch0. `r11`                          |
+| Trigger threshold          | 500 `r001`-`r004`                    |
+|                            | 300 `r005`                           |
+|                            | 100 `r006-r010`                      |
+|                            | 1 on ch0. `r11`, `r012`              |
+
+
+## Run overview:
+
+|          |                 |                         |                                                       |
+| :------- | :-------------- | :---------------------- | :---------------------------------------------------- |
+| **runs** | **# waveforms** | **pulser voltage (pp)** | **comment**                                           |
+| `r001`   | 5,000           | `300 mV`                | room temperature, not-used CSA output not terminated. |
+| `r002`   | 5,000           | `400 mV`                | "                                                     |
+| `r003`   | 5,000           | `500 mV`                | "                                                     |
+| `r004`   | 5,000           | `100 mV`                | "                                                     |
+| `r005`   | 5,000           | `50 mV`                 | "                                                     |
+| `r006`   | 5,000           | `25 mV`                 | "                                                     |
+| `r007`   | 5,000           | `150 mV`                | "                                                     |
+| `r008`   | 5,000           | `200 mV`                | "                                                     |
+| `r009`   | 5,000           | `250 mV`                | "                                                     |
+| `r010`   | 5,000           | `350 mV`                | "                                                     |
+| `r011`   | 100,000         | not connected to ASIC   | ", noise run                                          |
+|          |                 |                         |                                                       |
+| `r012`   | 100,000         | not connected to ASIC   | noise run. **89.9 K**, not-used CSA output terminated |
+| `r013`   | 5,000           | `25 mV`                 | **89.9 K**, not-used CSA output terminated            |
+| `r014`   | 5,000           | `50 mV`                 | "                                                     |
+| `r015`   | 5,000           | `100 mV`                | "                                                     |
+| `r016`   | 5,000           | `150 mV`                | "                                                     |
+| `r017`   | 5,000           | `200 mV`                | "                                                     |
+| `r018`   | 5,000           | `250 mV`                | "                                                     |
+| `r019`   | 5,000           | `300 mV`                | "                                                     |
+| `r020`   | 5,000           | `350 mV`                | "                                                     |
+| `r021`   | 5,000           | `400 mV`                | "                                                     |
+| `r022`   | 5,000           | `500 mV`                | "                                                     |
+|          |                 |                         |                                                       |
 
 
 ## Remarks and comments
-
-|          |                 |                         |             |
-| :------- | :-------------- | :---------------------- | :---------- |
-| **runs** | **# waveforms** | **pulser voltage (pp)** | **comment** |
-| `r001`   | 5,000           | `300 mV`                |             |
-| `r002`   | 5,000           | `400 mV`                |             |
-| `r003`   | 5,000           | `500 mV`                |             |
-| `r004`   | 5,000           | `100 mV`                |             |
-| `r005`   | 5,000           | `50 mV`                 |             |
-| `r006`   | 5,000           | `25 mV`                 |             |
-| `r007`   | 5,000           | `150 mV`                |             |
-| `r008`   | 5,000           | `200 mV`                |             |
-| `r009`   | 5,000           | `250 mV`                |             |
-| `r010`   | 5,000           | `350 mV`                |             |
-| `r011`   | 50,000          | not connected to ASIC   | noise run   |
-|          |                 |                         |             |
-
-
+We see a "wiggle" in the waveform (CSA output), which likely comes from reflections in the cables. For `r012` - `r022`, we added a termination on the CSA output channel that is *not* used. The resistance has tuned so that the wiggle became minimal.
 
 
 

--- a/ppc01/doc/cal/readme_cal_overview.md
+++ b/ppc01/doc/cal/readme_cal_overview.md
@@ -1,4 +1,4 @@
-## <img src="./../../logo/lbnl_logo.png" alt="logo" width="150"/> Teststand overview 
+## <img src="./../../logo/lbnl_logo.png" alt="logo" width="150"/> Teststand overview `cal` (cali)
 This is an overview of the LBNL teststand `ppc01` measurements. For more details on the individuals runs, see the readme files in this directory. 
 
 The follow the following naming scheme: `readme_<period>_<runs>.md`.  

--- a/ppc01/jldataprod/config/dsp/dsp_config_bch_default.json
+++ b/ppc01/jldataprod/config/dsp/dsp_config_bch_default.json
@@ -26,27 +26,27 @@
                 "unit": "µs"
             }, 
             "max": {
-                "val": 20.0,
+                "val": 6.5,
                 "unit": "µs"
             }
         },
         "tail_window": {
             "min": {
-                "val": 30.0,
+                "val": 8.5,
                 "unit": "µs"
             }, 
             "max": {
-                "val": 130.0,
+                "val": 40.9,
                 "unit": "µs"
             }
         },
         "current_window": {
             "min": {
-                "val": 18.0,
+                "val": 7.0,
                 "unit": "µs"
             }, 
             "max": {
-                "val": 300.0,
+                "val": 30.0,
                 "unit": "µs"
             }
         },
@@ -62,20 +62,19 @@
         "t0_threshold": 0.01, 
         "inTraceCut_std_threshold": 5,
         "sg_flt_degree": 3,
-        "ft_qmin": 0.02,
-        "ft_qmax": 0.98,
+        
         "e_grid_trap" : {
             "rt": {
                 "start": {
-                    "val": 1.5,
+                    "val": 0.2,
                     "unit": "µs"
                 },
                 "stop": {
-                    "val": 6.0,
+                    "val": 2.6,
                     "unit": "µs"
                 },
                 "step": {
-                    "val": 0.5,
+                    "val": 0.2,
                     "unit": "µs"
                 }
             },
@@ -234,8 +233,8 @@
                 "val": 100.0,
                 "unit": "ns"
             },
-            "ft_qmin": 0.02,
-            "ft_qmax": 0.98
+            "ft_qmin": 0.0,
+            "ft_qmax": 1.0
         }
     
     },
@@ -338,7 +337,7 @@
             },
             "nbins": 75,
             "rel_cut_fit": 0.05,
-            "peak": "Co60a"
+            "peak": "all"
         }
     }
 }

--- a/ppc01/jldataprod/config/dsp/dsp_config_bch_p01_noise.json
+++ b/ppc01/jldataprod/config/dsp/dsp_config_bch_p01_noise.json
@@ -3,22 +3,6 @@
         "enc_pickoff_trap": {
             "val": 18.0,
             "unit": "µs"
-        },
-        "enc_pickoff_zac": {
-            "val": 18.0,
-            "unit": "µs"
-        }, 
-        "enc_pickoff_cusp": {
-            "val": 18.0,
-            "unit": "µs"
-        }, 
-        "flt_length_cusp": {
-            "val": 30.0,
-            "unit": "µs"
-        }, 
-        "flt_length_zac": {
-            "val": 30.0,
-            "unit": "µs"
         }, 
         "bl_window": {
             "min": {
@@ -26,27 +10,27 @@
                 "unit": "µs"
             }, 
             "max": {
-                "val": 20.0,
+                "val": 40.0,
                 "unit": "µs"
             }
         },
         "tail_window": {
             "min": {
-                "val": 30.0,
+                "val": 40.1,
                 "unit": "µs"
             }, 
             "max": {
-                "val": 130.0,
+                "val": 40.9,
                 "unit": "µs"
             }
         },
         "current_window": {
             "min": {
-                "val": 18.0,
+                "val": 7.0,
                 "unit": "µs"
             }, 
             "max": {
-                "val": 300.0,
+                "val": 30.0,
                 "unit": "µs"
             }
         },
@@ -62,20 +46,19 @@
         "t0_threshold": 0.01, 
         "inTraceCut_std_threshold": 5,
         "sg_flt_degree": 3,
-        "ft_qmin": 0.02,
-        "ft_qmax": 0.98,
+        
         "e_grid_trap" : {
             "rt": {
                 "start": {
-                    "val": 1.5,
+                    "val": 0.2,
                     "unit": "µs"
                 },
                 "stop": {
-                    "val": 6.0,
+                    "val": 2.6,
                     "unit": "µs"
                 },
                 "step": {
-                    "val": 0.5,
+                    "val": 0.2,
                     "unit": "µs"
                 }
             },
@@ -92,80 +75,6 @@
                     "val": 0.2,
                     "unit": "µs"
                 }
-            }
-        },
-        "e_grid_zac" : {
-            "rt": {
-                "start": {
-                    "val": 1.5,
-                    "unit": "µs"
-                },
-                "stop": {
-                    "val": 6.0,
-                    "unit": "µs"
-                },
-                "step": {
-                    "val": 0.5,
-                    "unit": "µs"
-                }
-            },
-            "ft": {
-                "start": {
-                    "val": 1.0,
-                    "unit": "µs"
-                },
-                "stop": {
-                    "val": 4.0,
-                    "unit": "µs"
-                },
-                "step": {
-                    "val": 0.2,
-                    "unit": "µs"
-                }
-            }
-        },
-        "e_grid_cusp" : {
-            "rt": {
-                "start": {
-                    "val": 1.5,
-                    "unit": "µs"
-                },
-                "stop": {
-                    "val": 6.0,
-                    "unit": "µs"
-                },
-                "step": {
-                    "val": 0.5,
-                    "unit": "µs"
-                }
-            },
-            "ft": {
-                "start": {
-                    "val": 1.0,
-                    "unit": "µs"
-                },
-                "stop": {
-                    "val": 4.0,
-                    "unit": "µs"
-                },
-                "step": {
-                    "val": 0.2,
-                    "unit": "µs"
-                }
-            }
-        },
-        "a_grid_wl_sg": {
-            "start": {
-                "val": 30.0,
-                "unit": "ns"
-            },
-            "stop": {
-                "val": 350.0,
-                "unit": "ns"
-            },
-            "step": {
-                "val": 32.0,
-                "unit": "ns"
             }
         },
         "flt_defaults": {
@@ -233,9 +142,7 @@
             "intrace_mintot": {
                 "val": 100.0,
                 "unit": "ns"
-            },
-            "ft_qmin": 0.02,
-            "ft_qmax": 0.98
+            }
         }
     
     },
@@ -338,7 +245,7 @@
             },
             "nbins": 75,
             "rel_cut_fit": 0.05,
-            "peak": "Co60a"
+            "peak": "all"
         }
     }
 }

--- a/ppc01/jldataprod/config/dsp/dsp_config_p03_r045.json
+++ b/ppc01/jldataprod/config/dsp/dsp_config_p03_r045.json
@@ -73,7 +73,7 @@
                     "unit": "µs"
                 },
                 "step": {
-                    "val": 0.2,
+                    "val": 0.1,
                     "unit": "µs"
                 }
             }
@@ -105,6 +105,10 @@
                     "unit": "µs"
                 }
             }
+        },
+        "kwargs_pars": {
+            "ft_qmin": 0.0,
+            "ft_qmax": 1.0
         }
     },
     "pz": {

--- a/ppc01/jldataprod/config/dsp/validity.jsonl
+++ b/ppc01/jldataprod/config/dsp/validity.jsonl
@@ -9,4 +9,5 @@
 {"valid_from":"20250217T153437Z", "category":"cal", "apply":["dsp_config_default.json", "dsp_config_p03_r027.json"]}
 {"valid_from":"20250224T112325Z", "category":"cal", "apply":["dsp_config_default.json", "dsp_config_p03_r037.json"]}
 {"valid_from":"20250227T121431Z", "category":"cal", "apply":["dsp_config_default.json", "dsp_config_p03_r045.json"]}
-
+{"valid_from":"20250306T130439Z", "category":"bch", "apply":["dsp_config_bch_default.json"]}
+{"valid_from":"20250306T145307Z", "category":"bch", "apply":["dsp_config_bch_default.json", "dsp_config_bch_noise.json"]}

--- a/ppc01/jldataprod/config/energy/energy_config_p03_r045.json
+++ b/ppc01/jldataprod/config/energy/energy_config_p03_r045.json
@@ -1,20 +1,6 @@
 {
     "default": {
         "source": "th228",
-        "co60_lines": {
-            "val": [1173.237, 1332.501],
-            "unit": "keV"
-        },
-        "co60_names":  ["Co60a", "Co60b"],
-        "co60_left_window_sizes":   {
-            "val": [25.0,      25.0],
-            "unit": "keV"
-        },
-        "co60_right_window_sizes":  {
-            "val": [25.0,      25.0],
-            "unit": "keV"
-        },
-        "co60_fit_func": ["gamma_def", "gamma_def"],
         "n_bins": 15000,
         "quantile_perc": "NaN",
         "binning_peak_window": {
@@ -30,17 +16,17 @@
         "bin_width":0.01,
         "nbins_min": 50,
         "cal_pol_order": 1,
-        "cal_fit_excluded_peaks": [""],
+        "cal_fit_excluded_peaks": ["Tl208DEP", "Tl208SEP"],
         "cal_fit_max_tolerance": {
             "val": 1.5,
             "unit": "keV"
         },
         "fwhm_pol_order": 1,
-        "fwhm_fit_excluded_peaks": [""],
+        "fwhm_fit_excluded_peaks": ["Tl208DEP", "Tl208SEP"],
         "fwhm_fit_min_fwhm": {
             "val": 1.0,
             "unit": "keV"
         },
-        "energy_types": ["e_trap", "e_cusp"]
+        "energy_types": ["e_trap"]
     }
 }


### PR DESCRIPTION
- new docs for benchtest with pulser (`bch`, `p01`)
- add new dsp config parameters `dsp_config.kwargs_pars.ft_qmin`, `dsp_config.kwargs_pars.ft_qmin`. These are the quantiles that contain the fwhm values that are used in the flattop time optimization. (before these parameter were fixed to (0.02, 0.98). 